### PR TITLE
avoids attempt to split non string  content types

### DIFF
--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -7,7 +7,11 @@ module Paperclip
     def initialize(file, name, content_type)
       @file = file
       @name = name
-      @content_type = content_type || ""
+      if content_type && content_type.is_a?(String)
+        @content_type = content_type
+      else
+        @content_type = ""
+      end
     end
 
     def spoofed?


### PR DESCRIPTION
even with do_not_validate_attachment_file_type :pcrd a content_type of 0 
causes  the error i reported in

I think this could also be worked around by adding a custom mime type, but I don't think users should have to do that.
re #1942
