### PR TITLE
avoid comparing [] to inferred type

### DIFF
--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -41,8 +41,19 @@ module Paperclip
       supplied_media_type.present? && !media_types_from_name.include?(supplied_media_type)
     end
 
+    def supplied_type_mismatch?
+      if media_types_from_name.size == 0
+        false
+      else
+        supplied_media_type.present? && !media_types_from_name.include?(supplied_media_type)
+      end
+
+    end
+
     def calculated_type_mismatch?
-      if media_types_from_name.size > 0
+      if media_types_from_name.size == 0
+        false #cannot mismatch if there are media types from name
+      else
         !media_types_from_name.include?(calculated_media_type)
       end
     end

--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -42,7 +42,9 @@ module Paperclip
     end
 
     def calculated_type_mismatch?
-      !media_types_from_name.include?(calculated_media_type)
+      if media_types_from_name.size > 0
+        !media_types_from_name.include?(calculated_media_type)
+      end
     end
 
     def mapping_override_mismatch?


### PR DESCRIPTION
if there are no media types from name, we should not try to compare them with the `file` inferred type
fixes #1944
